### PR TITLE
Try to modify the icon before adding a new one

### DIFF
--- a/windows/notify_windows.go
+++ b/windows/notify_windows.go
@@ -394,9 +394,11 @@ func (ni *NotifyIcon) windowProc(wnd windows.Handle, msg uint32, wParam, lParam 
 		// disable Alt+F4
 	default:
 		if msg == _WM_TASKBARCREATED {
-			atomic.StoreInt32(&ni.added, 0)
-			if err := ni.Add(); err != nil {
-				panic(err)
+			if ni.Modify() != nil {
+				atomic.StoreInt32(&ni.added, 0)
+				if err := ni.Add(); err != nil {
+					panic(err)
+				}
 			}
 		}
 		return sys.DefWindowProc(wnd, msg, wParam, lParam)


### PR DESCRIPTION
When the WM_TASKBARCREATED event is raised, the icon may still exist and fail to get added, i.e., changing the display scale, this will cause panic in go.notify.